### PR TITLE
feat(homelab-dns): add external-dns support

### DIFF
--- a/homelab-dns/README.md
+++ b/homelab-dns/README.md
@@ -1,0 +1,25 @@
+## Deployment
+
+1. `k create ns homelab-dns`
+1. `k apply -f etcd.yaml -f dns.yaml`
+   Note: corefile is now only configured to use etcd for `homelab.local` domains.
+1. Confrim coredns is working: `dig @192.168.1.240 google.com`
+1. Deploy external-dns to synchronize ingress A record
+   ```
+   k apply -f external-dns.yaml
+   ```
+
+## Ingress Example
+
+If your ingress is configured as `<your-service>.homelab.local`, run following command to confirm the synchronization of ingress record.
+
+```bash
+curl --dns-servers 192.168.1.240 http://<your-service>.homelab.local
+```
+
+If `--dns-servers` option is not supported in your `curl`, try
+```bash
+docker run --rm alpine/curl --dns-servers 192.168.1.240 http://<your-service>.homelab.local
+```
+
+If you want to access ingress service with your client PC, configure the target DNS server to use coreDNS loadBalancerIP (`192.168.1.240` in this case).

--- a/homelab-dns/dns.yaml
+++ b/homelab-dns/dns.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns
+  namespace: homelab-dns
+spec:
+  ports:
+    - port: 53
+      name: dns-udp
+      protocol: UDP
+      targetPort: 53
+    - port: 53
+      name: dns-tcp
+      protocol: TCP
+      targetPort: 53
+  selector:
+    app: coredns
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.240
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: homelab-dns
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: coredns
+  template:
+    metadata:
+      labels:
+        app: coredns
+    spec:
+      containers:
+        - name: coredns
+          image: coredns/coredns:latest
+          ports:
+            - containerPort: 53
+              name: dns-udp
+              protocol: UDP
+            - containerPort: 53
+              name: dns-tcp
+              protocol: TCP
+          args: [ "-conf", "/etc/coredns/Corefile" ]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: homelab-dns
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        ready
+        etcd homelab.local {
+          endpoint http://dns-etcd:2379
+          path /skydns
+          fallthrough
+        }
+        forward . 192.168.1.254
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+---

--- a/homelab-dns/etcd.yaml
+++ b/homelab-dns/etcd.yaml
@@ -1,0 +1,57 @@
+# need etcd backend to make external-dns work
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dns-etcd
+  namespace: homelab-dns
+spec:
+  serviceName: dns-etcd
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dns-etcd
+  template:
+    metadata:
+      labels:
+        app: dns-etcd
+    spec:
+      containers:
+      - name: dns-etcd
+        image: quay.io/coreos/etcd:v3.6.4
+        ports:
+        - containerPort: 2379
+        - containerPort: 2380
+        command:
+        - /usr/local/bin/etcd
+        - --name=etcd-0
+        - --data-dir=/var/lib/etcd
+        - --advertise-client-urls=http://0.0.0.0:2379
+        - --listen-client-urls=http://0.0.0.0:2379
+        - --listen-peer-urls=http://0.0.0.0:2380
+        volumeMounts:
+        - name: dns-etcd-data
+          mountPath: /var/lib/etcd
+  volumeClaimTemplates:
+  - metadata:
+      name: dns-etcd-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-etcd
+  namespace: homelab-dns
+spec:
+  clusterIP: None
+  ports:
+  - port: 2379
+    name: client
+  - port: 2380
+    name: peer
+  selector:
+    app: dns-etcd
+---

--- a/homelab-dns/external-dns.yaml
+++ b/homelab-dns/external-dns.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services","pods"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["get","watch","list"]
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get","watch","list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:v0.18.0
+        args:
+        - --source=ingress
+        - --provider=coredns
+        - --policy=sync
+        env:
+        - name: ETCD_URLS
+          value: http://dns-etcd.homelab-dns:2379


### PR DESCRIPTION
This change adds CoreDNS as intra-DNS to resolve A records of ingress services using external-dns.