### PR TITLE
fix(homelab-dns): fix etcd initial cluster

### DIFF
--- a/homelab-dns/etcd.yaml
+++ b/homelab-dns/etcd.yaml
@@ -28,6 +28,9 @@ spec:
         - --advertise-client-urls=http://0.0.0.0:2379
         - --listen-client-urls=http://0.0.0.0:2379
         - --listen-peer-urls=http://0.0.0.0:2380
+        - --initial-advertise-peer-urls=http://etcd-0.dns-etcd.homelab-dns.svc.cluster.local:2380
+        - --initial-cluster=etcd-0=http://etcd-0.dns-etcd.homelab-dns.svc.cluster.local:2380
+        - --initial-cluster-state=new
         volumeMounts:
         - name: dns-etcd-data
           mountPath: /var/lib/etcd
@@ -38,7 +41,7 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: 512Mi
+          storage: 256Mi
 ---
 apiVersion: v1
 kind: Service

--- a/homelab-dns/external-dns.yaml
+++ b/homelab-dns/external-dns.yaml
@@ -60,6 +60,7 @@ spec:
         - --source=ingress
         - --provider=coredns
         - --policy=sync
+        # - --log-level=debug
         env:
         - name: ETCD_URLS
           value: http://dns-etcd.homelab-dns:2379


### PR DESCRIPTION
This change fixes the issue that etcd fails to write after restart. Adding `inital-cluster` option will specify that etcd-0 is the inital master after restart.

Fixes #9 