### PR TITLE
chore: bound mongo to amd64 node

### DIFF
--- a/librechat/values.yaml
+++ b/librechat/values.yaml
@@ -60,10 +60,13 @@ readinessProbe:
 # MongoDB Parameters
 mongodb:
   image:
-    # overwright image to suppport arm64
+    # if you want to deploy mongo to arm64 node, overwrite image to suppport arm64
     # see https://github.com/bitnami/charts/issues/3635#issuecomment-2628385764
-    repository: dlavrenuek/bitnami-mongodb-arm
+    # repository: dlavrenuek/bitnami-mongodb-arm
     tag: 7.0.15
+  nodeSelector:
+    # force scheduling to amd64 node
+    kubernetes.io/arch: amd64
   enabled: true
   auth:
     enabled: false


### PR DESCRIPTION
mongodb is crashing as it was scheduled to newly added amd64 node, but dlavrenuek/bitnami-mongodb-arm only supports arm64.
I rolled back the image to official one and added node selector to ensure that mongo is always scheduled to amd64 node.